### PR TITLE
Protocol::WebSocket::Frame->to_frame should be Protocol::WebSocket::Frame

### DIFF
--- a/lib/ReAnimator/AtomDecorator.pm
+++ b/lib/ReAnimator/AtomDecorator.pm
@@ -47,7 +47,7 @@ sub send_message {
     my ($self, $message) = @_;
 
     my $frame = Protocol::WebSocket::Frame->new($message);
-    $self->write($frame->to_string);
+    $self->write($frame->to_bytes);
 }
 
 sub _build_frame { shift; Protocol::WebSocket::Frame->new(@_) }


### PR DESCRIPTION
Protocol::WebSocket::Frame->to_frame should be Protocol::WebSocket::Frame->to_bytes now perhaps?  for version 0.00902 and greater, https://github.com/vti/protocol-websocket/blob/c571246381a2c674c040affac523724da5b231c5/Changes
